### PR TITLE
Adding probability density location back into the code

### DIFF
--- a/PyProgs/locations_prob.py
+++ b/PyProgs/locations_prob.py
@@ -40,140 +40,6 @@ def read_prob_locs_from_file(filename):
 
   return locs
  
-def trigger_detections(st_max,loc_level):
-
-  logging.debug('Detecting using loc_level = %.2f'%loc_level)
-  detections=[]
-  for tr in st_max:
-    trigs=trigger.triggerOnset(tr.data,loc_level,loc_level)
-    logging.debug('Found %d triggers.'%len(trigs))
-
-    for trig in trigs:
-      t_start=tr.stats.starttime+trig[0]*tr.stats.delta
-      t_end=tr.stats.starttime+trig[1]*tr.stats.delta
-      detections.append((t_start,t_end))
-
-  return detections
-
-def compute_stats_from_4Dgrid(opdict,starttime,endtime):
-  
-  base_path=opdict['base_path']
-  datadir=opdict['datadir']
-  outdir=opdict['outdir']
-  # directories
-  lib_path = os.path.join(base_path,'lib')
-  data_path= os.path.join(base_path,'data',datadir)
-  out_path = os.path.join(base_path,'out',outdir)
-  grid_path= os.path.join(base_path,'out',outdir,'grid')
-  loc_path = os.path.join(base_path,'out',outdir,'loc')
-  fig_path = os.path.join(base_path,'out',outdir,'fig')
-
-
-  # files
-  search_grid=opdict['search_grid']
-  time_grid=opdict['time_grid']
-  stations=opdict['stations']
-  kurt_glob=opdict['kurtglob']
-  grad_glob=opdict['gradglob']
-
-  hdr_file = os.path.join(lib_path,search_grid)
-  grid_filename_base=os.path.join(lib_path,time_grid)
-  stations_filename= os.path.join(lib_path,stations)
-  search_grid_filename= hdr_file
-  kurt_files=glob.glob(os.path.join(data_path,kurt_glob))
-  grad_files=glob.glob(os.path.join(data_path,grad_glob))
-  kurt_files.sort()
-  grad_files.sort()
-
-  # set up information for migration
-  sta=StationList()
-  sta.read_from_file(stations_filename)
-
-  cha=ChannelList()
-  cha.populate_from_station_list_and_data_files(sta,kurt_files)
-
-  time_grid=QDTimeGrid()
-  time_grid.read_NLL_hdr_file(hdr_file)
-  time_grid.populate_from_time_grids(grid_filename_base,cha,out_path,load_buf=True)
-
-  max_grid_time=0.0
-  for point in time_grid.buf:
-    max_time_tmp=max(point.values())
-    max_grid_time=max(max_grid_time,max_time_tmp)
-  
-  # get grid geometry information
-  dummy_grid=QDGrid()
-  dummy_grid.read_NLL_hdr_file(hdr_file)
-  (nx,ny,nz)=(dummy_grid.nx, dummy_grid.ny, dummy_grid.nz)
-  (dx,dy,dz)=(dummy_grid.dx, dummy_grid.dy, dummy_grid.dz)
-  (x_orig,y_orig,z_orig)=(dummy_grid.x_orig, dummy_grid.y_orig, dummy_grid.z_orig)
-
-  # TODO
-  # clean up data (preselect on signal to noise ratios etc)
-
-  logging.info("Processing time slice %s - %s "%(starttime.isoformat(),endtime.isoformat()))
- 
-  endtime=endtime+2*max_grid_time
-  starttime=starttime-2*max_grid_time
-  logging.info("Expanding to time slice %s - %s to account for propagation time"%(starttime.isoformat(),endtime.isoformat()))
-
-  time_dict=time_grid.buf[0]
-
-  # read data into a dictionary
-
-  logging.info("Reading processed data into dictionary")
-  data=read_data_compatible_with_time_dict(grad_files, time_dict, starttime, endtime)
-
-  # Set the global variable delta (dt for all the seismograms)
-  try:
-    delta=data.values()[0].delta
-  except IndexError:
-    raise UserWarning("File list empty - check --dataglob option")
-
-  # DO MIGRATION
-  n_buf, norm_stack_len, stack_shift_time, stack_start_time, stack_grid = do_innermost_migration_loop(starttime, endtime, data, time_grid, delta, search_grid_filename)
-
-  # set up integration limits
-  x=np.arange(nx)*dx+x_orig
-  y=np.arange(ny)*dy+y_orig
-  z=np.arange(nz)*dz+z_orig
-  t=np.arange(norm_stack_len)*delta
-  
-  #logging.debug('Expected shape of time axis : %s, actual shape : %s.  Shape of 4D grid : %s.'%(norm_stack_len, x.shape, stack_grid.shape))
-
-  # normalize grid for first probability density calculation
-  stack_grid_int=compute_integral4D(stack_grid[:,:,:,0:norm_stack_len],x,y,z,t)
-  stack_grid_norm=stack_grid[:,:,:,0:norm_stack_len] / stack_grid_int
-
- 
-  # integrate normalized grid over all space dimensions to get marginal over time
-  prob_t = si.trapz(si.trapz(si.trapz(stack_grid_norm,x=x,axis=0),x=y,axis=0),x=z,axis=0)
-  exp_t = si.trapz(t*prob_t,x=t,axis=0)
-  var_t = si.trapz((t-exp_t)*(t-exp_t)*prob_t,x=t,axis=0)
-  sigma_t = np.sqrt(var_t)
-  it_exp=int(round(exp_t/delta))
-  nt_sigma=int(round(sigma_t/delta))
-  it_left=it_exp-nt_sigma
-  it_right=it_exp+nt_sigma
-  t_slice=t[it_left:it_right]
- 
-  exp_x,exp_y,exp_z,exp_t,cov_matrix,prob_dict = compute_expected_coordinates4D(stack_grid[:,:,:,it_exp-nt_sigma:it_exp+nt_sigma],x,y,z,t_slice,return_2Dgrids=True)
-  sigma_x=np.sqrt(cov_matrix[0,0])
-  sigma_y=np.sqrt(cov_matrix[1,1])
-  sigma_z=np.sqrt(cov_matrix[2,2])
-  sigma_t=np.sqrt(cov_matrix[3,3])
-
-  # turn origin time into utcDateTime object
-  exp_otime = stack_start_time + exp_t
-
-
-  loc=(exp_otime,sigma_t,exp_x,sigma_x,exp_y,sigma_y,exp_z,sigma_z)
-
-  # do plotting
-  fig_name=os.path.join(fig_path,'fig_st_mpl_%s'%exp_otime.isoformat())
-  plot_probloc_mpl(prob_dict,[x,y,z,t_slice],fig_name)
-
-  return loc
 
 def do_locations_prob_setup_and_run(opdict,space_only=True):
 
@@ -182,6 +48,7 @@ def do_locations_prob_setup_and_run(opdict,space_only=True):
 
   locfile=os.path.join(base_path,'out',opdict['outdir'],'loc','locations.dat')
   locfile_prob=os.path.join(base_path,'out',opdict['outdir'],'loc','locations_prob.dat')
+  locfile_hdf5=os.path.join(base_path,'out',opdict['outdir'],'loc','locations_prob.hdf5')
   f_prob=open(locfile_prob,'w')
 
   # if locfile does not exist then make it by running trigger location
@@ -219,6 +86,8 @@ def do_locations_prob_setup_and_run(opdict,space_only=True):
   # read locations
   locs=read_locs_from_file(locfile)
 
+  # prepare file for output of marginals
+  f_marginals = h5py.File(locfile_hdf5,'w')
 
   # iterate over locations
   for loc in locs:
@@ -295,7 +164,7 @@ def do_locations_prob_setup_and_run(opdict,space_only=True):
         exp_x, exp_y, exp_z, exp_t, cov_matrix, prob_dict = \
             compute_expected_coordinates4D(stack_4D,x,y,z,t,return_2Dgrids=True)
     
-    # save the marginals to a hdf5 file in loc subdirectory
+
 
     # put reference location back
     exp_x = exp_x + x_orig
@@ -314,6 +183,25 @@ def do_locations_prob_setup_and_run(opdict,space_only=True):
         sig_x,sig_y,sig_z,sig_t = np.sqrt(np.diagonal(cov_matrix))
 
 
+    # save the marginals to a hdf5 file in loc subdirectory (f_marginals)
+    # each event becomes a group in this one file
+    grp = f_marginals.create_group(exp_t.isoformat())
+    grp.create_dataset('x',data=x+x_orig)
+    grp.create_dataset('y',data=y+y_orig)
+    grp.create_dataset('z',data=z+y_orig)
+    grp.create_dataset('prob_x',data=prob_dict['prob_x0'])
+    grp.create_dataset('prob_y',data=prob_dict['prob_x1'])
+    grp.create_dataset('prob_z',data=prob_dict['prob_x2'])
+    grp.create_dataset('prob_xy',data=prob_dict['prob_x0_x1'])
+    grp.create_dataset('prob_xz',data=prob_dict['prob_x0_x2'])
+    grp.create_dataset('prob_yz',data=prob_dict['prob_x1_x2'])
+    if not space_only:
+        grp.create_dataset('t',data=t-(o_time - start_time))
+        grp.create_dataset('prob_t',data=prob_dict['prob_x3'])
+        grp.create_dataset('prob_xt',data=prob_dict['prob_x0_x3'])
+        grp.create_dataset('prob_yt',data=prob_dict['prob_x1_x3'])
+        grp.create_dataset('prob_zt',data=prob_dict['prob_x2_x3'])
+
 
     # write the expected values to a plain text locations file
 
@@ -321,8 +209,9 @@ def do_locations_prob_setup_and_run(opdict,space_only=True):
 y= %.4f pm %.4f km, z= %.4f pm %.4f km\n" % (exp_t.isoformat(), sig_t, \
       exp_x, sig_x, exp_y, sig_y, exp_z, sig_z))
 
-  # close location file
+  # close location files
   f_prob.close()
+  f_marginals.close()
 
 
 

--- a/PyProgs/locations_trigger.py
+++ b/PyProgs/locations_trigger.py
@@ -196,13 +196,15 @@ def do_locations_trigger_setup_and_run(opdict):
 
   nt_full=int((last_end_time-first_start_time)/dt)+1
 
+  import pdb; pdb.set_trace()
+
   # create - assume all stacks are of the same length and will be concatenated end to end 
   #          (this will give more than enough space) 
   f = h5py.File(os.path.join(stack_path,'combined_stack_all.hdf5'),'w')
-  cmax_val = f.create_dataset('max_val',(nt_full,), 'f', chunks=(nt0,))
-  cmax_x = f.create_dataset('max_x',(nt_full,), 'f', chunks=(nt0,))
-  cmax_y = f.create_dataset('max_y',(nt_full,), 'f', chunks=(nt0,))
-  cmax_z = f.create_dataset('max_z',(nt_full,), 'f', chunks=(nt0,))
+  cmax_val = f.create_dataset('max_val',(nt_full,), 'f', chunks=(nt_full,))
+  cmax_x = f.create_dataset('max_x',(nt_full,), 'f', chunks=(nt_full,))
+  cmax_y = f.create_dataset('max_y',(nt_full,), 'f', chunks=(nt_full,))
+  cmax_z = f.create_dataset('max_z',(nt_full,), 'f', chunks=(nt_full,))
 
   # concatenate unsmoothed versions of max_val to avoid 
   # problems at file starts and ends

--- a/PyProgs/locations_trigger.py
+++ b/PyProgs/locations_trigger.py
@@ -176,27 +176,25 @@ def do_locations_trigger_setup_and_run(opdict):
   # get basic info from first file
   f_stack = h5py.File(stack_files[0],'r')
   max_val = f_stack['max_val']
-  nt0 = len(max_val)
-  first_start_time = utcdatetime.UTCDateTime(max_val.attrs['start_time'])
   dt = max_val.attrs['dt']
   f_stack.close()
 
-  # get start time
-  f_stack = h5py.File(stack_files[0],'r')
-  max_val = f_stack['max_val']
-  first_start_time = utcdatetime.UTCDateTime(max_val.attrs['start_time'])
-  dt = max_val.attrs['dt']
-  f_stack.close()
-
-  # get end time
-  f_stack = h5py.File(stack_files[-1],'r')
-  max_val = f_stack['max_val']
-  last_end_time = utcdatetime.UTCDateTime(max_val.attrs['start_time'])+dt*len(max_val)
-  f_stack.close()
-
+  # get start times  (get first and last times)
+  start_times=[]
+  end_times=[]
+  for fname in stack_files:
+    f_stack = h5py.File(fname,'r')
+    max_val = f_stack['max_val']
+    start_times.append(utcdatetime.UTCDateTime(max_val.attrs['start_time']))
+    end_times.append(  utcdatetime.UTCDateTime(max_val.attrs['start_time'])+dt*len(max_val))
+    f_stack.close()
+  
+  #import pdb; pdb.set_trace()
+  first_start_time = min(start_times)
+  last_end_time = max(end_times)
+    
   nt_full=int((last_end_time-first_start_time)/dt)+1
 
-  import pdb; pdb.set_trace()
 
   # create - assume all stacks are of the same length and will be concatenated end to end 
   #          (this will give more than enough space) 

--- a/PyProgs/locations_trigger.py
+++ b/PyProgs/locations_trigger.py
@@ -189,7 +189,6 @@ def do_locations_trigger_setup_and_run(opdict):
     end_times.append(  utcdatetime.UTCDateTime(max_val.attrs['start_time'])+dt*len(max_val))
     f_stack.close()
   
-  #import pdb; pdb.set_trace()
   first_start_time = min(start_times)
   last_end_time = max(end_times)
     

--- a/PyProgs/test/test_location.py
+++ b/PyProgs/test/test_location.py
@@ -2,7 +2,8 @@ import os, glob, unittest
 import numpy as np
 from options import WavelocOptions
 from OP_waveforms import Waveform
-from locations_trigger import do_locations_trigger_setup_and_run, trigger_locations_inner
+from locations_trigger import do_locations_trigger_setup_and_run, \
+    trigger_locations_inner, read_locs_from_file
 from locations_prob import do_locations_prob_setup_and_run
 from NllGridLib import *
 from integrate4D import *
@@ -158,16 +159,26 @@ class LocationTests(unittest.TestCase):
     outdir=self.wo.opdict['outdir']
 
     exp_loc_fname = os.path.join(base_path,test_datadir,'TEST_locations.dat')
-    exp_loc_file = open(exp_loc_fname,'r') 
-    exp_lines=exp_loc_file.readlines()
+    exp_locs=read_locs_from_file(exp_loc_fname)
 
     do_locations_trigger_setup_and_run(self.wo.opdict)
 
     loc_fname = os.path.join(base_path,'out',outdir,'loc','locations.dat')
-    loc_file = open(loc_fname,'r') 
-    lines=loc_file.readlines()
+    locs=read_locs_from_file(loc_fname)
 
-    self.assertEquals(lines,exp_lines)
+    self.assertEqual(len(locs),len(exp_locs))
+    for i in xrange(len(locs)):
+      loc=locs[i]
+      exp_loc=exp_locs[i]
+      self.assertGreater(loc['o_time'] , exp_loc['o_time']-exp_loc['o_err_left'])
+      self.assertLess(loc['o_time'] ,    exp_loc['o_time']+exp_loc['o_err_right'])
+      self.assertLess(np.abs(loc['x_mean']-exp_loc['x_mean']), exp_loc['x_sigma'])
+      self.assertLess(np.abs(loc['x_mean']-exp_loc['x_mean']),     loc['x_sigma'])
+      self.assertLess(np.abs(loc['y_mean']-exp_loc['y_mean']), exp_loc['y_sigma'])
+      self.assertLess(np.abs(loc['y_mean']-exp_loc['y_mean']),     loc['y_sigma'])
+      self.assertLess(np.abs(loc['z_mean']-exp_loc['z_mean']), exp_loc['z_sigma'])
+      self.assertLess(np.abs(loc['z_mean']-exp_loc['z_mean']),     loc['z_sigma'])
+
 
   @unittest.skip('Not running full resolution trigger test')
   def test_locations_trigger_fullRes(self):


### PR DESCRIPTION
This mostly concerns the probability location code, so should not break anything.  I've tested it with the full battery of tests and all is ok.

@nlanget
One exception to the above statement : I've also re-fixed the getting of first start and last end times of stacks before combining (in locations_trigger).  Previous version assumed that the end time of file n would be later than that of file n-1, which is not always the case, especially if the directory contains a mix of files.  This version now reads start and end times from all files before choosing first start and last end times:

```
  # get start times  (get first and last times)
  start_times=[]
  end_times=[]
  for fname in stack_files:
    f_stack = h5py.File(fname,'r')
    max_val = f_stack['max_val']
    start_times.append(utcdatetime.UTCDateTime(max_val.attrs['start_time']))
    end_times.append(  utcdatetime.UTCDateTime(max_val.attrs['start_time'])+dt*len(max_val))
    f_stack.close()

  first_start_time = min(start_times)
  last_end_time = max(end_times)

  nt_full=int((last_end_time-first_start_time)/dt)+1

```
