### PR TITLE
Move furthermost events to the cluster centroid for better DD relocation

### DIFF
--- a/PyProgs/SDS_processing.py
+++ b/PyProgs/SDS_processing.py
@@ -28,6 +28,11 @@ def do_SDS_processing_setup_and_run(opdict):
   filter_c2=opdict['c2']
   kurt_window=opdict['kwin']
 
+  dataglob=opdict['dataglob']
+  kurtglob=opdict['kurtglob']
+  gradglob=opdict['gradglob']
+  gaussglob=opdict['gaussglob']
+
   # start and end time to process
   start_time=utcdatetime.UTCDateTime(opdict['starttime'])
   end_time=utcdatetime.UTCDateTime(opdict['endtime'])
@@ -53,7 +58,7 @@ def do_SDS_processing_setup_and_run(opdict):
         logging.debug("Full path : %s"%full_path)
         if os.path.exists(full_path):
 
-          filt_filename=os.path.join(data_dir,"%s.%s.%s.%s.filt.mseed"%(start_time.isoformat(),net,sta,comp))
+          filt_filename=os.path.join(data_dir,"%s.%s.%s.%s.%s"%(start_time.isoformat(),net,sta,comp,dataglob[1:]))
           logging.debug("Processing to create %s" % (filt_filename))
           wf=Waveform()
           try:
@@ -63,13 +68,13 @@ def do_SDS_processing_setup_and_run(opdict):
               wf.resample(opdict['fs'])
             wf.write_to_file_filled(filt_filename,format='MSEED',fill_value=0)
 
-            kurt_filename=os.path.join(data_dir,"%s.%s.%s.%s.filt_kurt.mseed"%(start_time.isoformat(),net,sta,comp))
+            kurt_filename=os.path.join(data_dir,"%s.%s.%s.%s.%s"%(start_time.isoformat(),net,sta,comp,kurtglob[1:]))
             logging.debug("Processing to create %s" % (kurt_filename))
             wf.process_kurtosis(kurt_window,recursive=opdict['krec'],pre_taper=True, post_taper=True)
             wf.write_to_file_filled(kurt_filename,format='MSEED',fill_value=0)
 
             if opdict['kderiv']:
-              kurt_grad_filename=os.path.join(data_dir,"%s.%s.%s.%s.filt_kurt_grad.mseed"%(start_time.isoformat(),net,sta,comp))
+              kurt_grad_filename=os.path.join(data_dir,"%s.%s.%s.%s.%s"%(start_time.isoformat(),net,sta,comp,gradglob[1:]))
               logging.debug("Processing to create %s" % (kurt_grad_filename))
               wf.take_positive_derivative(pre_taper=True,post_taper=True)
               wf.write_to_file_filled(kurt_grad_filename,format='MSEED',fill_value=0)
@@ -78,7 +83,7 @@ def do_SDS_processing_setup_and_run(opdict):
               thres=opdict['gthreshold']
               mu=opdict['mu']
               sigma=opdict['sigma']
-              gauss_filename=os.path.join(data_dir,"%s.%s.%s.%s.filt_kurt_grad_gauss.mseed"%(start_time.isoformat(),net,sta,comp))
+              gauss_filename=os.path.join(data_dir,"%s.%s.%s.%s.%s"%(start_time.isoformat(),net,sta,comp,gaussglob[1:]))
               logging.debug("Processing to create %s" % (gauss_filename))
               wf.process_gaussian(thres,mu,sigma)
               wf.write_to_file_filled(gauss_filename,format='MSEED',fill_value=0)

--- a/PyProgs/clustering.py
+++ b/PyProgs/clustering.py
@@ -96,8 +96,6 @@ def plot_traces(CLUSTER, delay_file, coeff, locs, stations, datadir, data_files,
               c='r'
             ax.text(0.5,0.5,"%s, %s, %s"%(name,str(coeff[name][e1-1][e2-1]),str(delay[name][e1-1][e2-1])),color=c)
         fig.suptitle("Cluster : %s ; Event pair : (%s,%s) ; %d"%(str(i),str(e1),str(e2),co))
-        plt.clf()
-        plt.close()
         plt.show()
 
         # Plot location
@@ -151,7 +149,7 @@ def compute_nbsta(event,coeff,threshold):
       c=0
       if i!=j:
         for name in sorted(coeff):
-          if coeff[name] and coeff[name][i][j] >= threshold:
+          if coeff[name] and coeff[name][i][j] >= threshold and coeff[name][i][j] != 'NaN':
             c=c+1
         liste.append(c)
       else:
@@ -171,9 +169,6 @@ def do_clustering(event,nbsta,nbmin):
   for I in range(event):
     voisins_du_sommet_I__verti=(np.where(nbsta[:,I]>=nbmin)[0]).tolist()[0]
     voisins_du_sommet_I__horiz=(np.where(nbsta[I,:]>=nbmin)[1]).tolist()[0]
-    #GRAPH.voisins.append(voisins_du_sommet_I__verti+voisins_du_sommet_I__horiz)
-    #GRAPH.flag.append(0)
-    #GRAPH.cluster_index.append(0)
     GRAPH.set_voisins(voisins_du_sommet_I__verti+voisins_du_sommet_I__horiz)
     GRAPH.set_flag(0)
     GRAPH.set_cluster_index(0)

--- a/PyProgs/clustering.py
+++ b/PyProgs/clustering.py
@@ -8,7 +8,6 @@ import cProfile
 from CZ_Clust_2_color import *
 from CZ_W_2_color import *
 import cPickle
-from mayavi import mlab
 from OP_waveforms import *
 import logging
 from correlation import BinaryFile
@@ -208,6 +207,8 @@ def do_clustering(event,nbsta,nbmin):
 
 # -----------------------------------------------------------------------------------------
 def plot_graphs(locs,stations,nbsta,CLUSTER,nbmin,threshold):
+  from mayavi import mlab
+
   # Event coordinates
   stack_x,stack_y,stack_z=[],[],[]
   for loc in locs:

--- a/PyProgs/clustering.py
+++ b/PyProgs/clustering.py
@@ -66,8 +66,7 @@ def plot_traces(CLUSTER, delay_file, coeff, locs, stations, datadir, data_files,
     dt=wf.delta
     tdeb=wf.starttime
 
-  list_name=tr.keys()
-  list_name.sort()
+  list_name=sorted(tr)
 
   for i in range(1,len(CLUSTER)+1): # cluster index
     for j in range(len(CLUSTER[i])): # first event index
@@ -97,7 +96,9 @@ def plot_traces(CLUSTER, delay_file, coeff, locs, stations, datadir, data_files,
               c='r'
             ax.text(0.5,0.5,"%s, %s, %s"%(name,str(coeff[name][e1-1][e2-1]),str(delay[name][e1-1][e2-1])),color=c)
         fig.suptitle("Cluster : %s ; Event pair : (%s,%s) ; %d"%(str(i),str(e1),str(e2),co))
-        #plt.savefig('/home/nadege/Desktop/correlation.png')
+        plt.clf()
+        plt.close()
+        plt.show()
 
         # Plot location
         fig = plt.figure()
@@ -149,7 +150,7 @@ def compute_nbsta(event,coeff,threshold):
     for j in xrange(i,event):
       c=0
       if i!=j:
-        for name in coeff.keys():
+        for name in sorted(coeff):
           if coeff[name] and coeff[name][i][j] >= threshold:
             c=c+1
         liste.append(c)
@@ -221,7 +222,7 @@ def plot_graphs(locs,stations,nbsta,CLUSTER,nbmin,threshold):
 
   # Extract coordinates
   xsta,ysta,zsta=[],[],[]
-  for sta in stations.keys():
+  for sta in sorted(stations):
     xsta.append(stations[sta]['x'])
     ysta.append(stations[sta]['y'])
     zsta.append(stations[sta]['elev'])

--- a/PyProgs/correlation.py
+++ b/PyProgs/correlation.py
@@ -253,6 +253,7 @@ def do_correlation_setup_and_run(opdict):
   print "Elapsed time: ",time.time()-tref
 
   # Save the results in 2 binary files
+  logging.info("Saving coeff and delay files")
   a=BinaryFile(coeff_file)
   a.write_binary_file(coeff)
 

--- a/PyProgs/double_diff.py
+++ b/PyProgs/double_diff.py
@@ -43,9 +43,6 @@ def fill_matrix(cluster,x,y,z,t_orig,stations,t_th,t_arr,coeff,delay,threshold):
   N=len(cluster)
   nline,num=0,0
 
-  from clustering import compute_nbsta
-  nbsta=compute_nbsta(len(coeff[coeff.keys()[0]]),coeff,threshold)
-
   for staname in sorted(stations):
     if not staname in delay.keys():
       continue

--- a/PyProgs/locations_trigger.py
+++ b/PyProgs/locations_trigger.py
@@ -70,20 +70,22 @@ def number_good_kurtosis_for_location(kurt_files,data_files,loc,time_dict,snr_li
     st=read(kfilename,headonly=True)
     staname=st.traces[0].stats.station
 
-    traveltime=time_dict[staname].value_at_point(stack_x,stack_y,stack_z)
-    start_time=o_time+traveltime-sn_time
-    end_time=o_time+traveltime+sn_time
-    try:
-      wf.read_from_file(kfilename,starttime=start_time,endtime=end_time)
-      snr=wf.get_snr(o_time+traveltime,start_time,end_time)
+    if staname in time_dict.keys():
+      traveltime=time_dict[staname].value_at_point(stack_x,stack_y,stack_z)
+      start_time=o_time+traveltime-sn_time
+      end_time=o_time+traveltime+sn_time
+      try:
+        wf.read_from_file(kfilename,starttime=start_time,endtime=end_time)
+        snr=wf.get_snr(o_time+traveltime,start_time,end_time)
 
-      wf.read_from_file(dfilename,starttime=start_time,endtime=end_time)
-      snr_tr=wf.get_snr(o_time+traveltime,start_time,end_time)
+        wf.read_from_file(dfilename,starttime=start_time,endtime=end_time)
+        snr_tr=wf.get_snr(o_time+traveltime,start_time,end_time)
 
-      if snr > snr_limit and snr_tr > snr_tr_limit:
-        n_good_kurt = n_good_kurt + 1
-    except UserWarning:
-      logging.info('No data around %s for file %s.'%(o_time.isoformat(),filename))
+        if snr > snr_limit and snr_tr > snr_tr_limit:
+          n_good_kurt = n_good_kurt + 1
+      except UserWarning:
+        logging.info('No data around %s for file %s.'%(o_time.isoformat(),kfilename))
+
   return n_good_kurt
 
 def trigger_locations_inner(max_val,max_x,max_y,max_z,left_trig,right_trig,start_time,delta):    

--- a/PyProgs/options.py
+++ b/PyProgs/options.py
@@ -332,9 +332,9 @@ class WavelocOptions(object):
     self.opdict['data_overlap']=20
 
     self.opdict['dataglob']='*filt.mseed'
-    self.opdict['kurtglob']='*kurt.mseed'
-    self.opdict['gradglob']='*grad.mseed'
-    self.opdict['gaussglob']='*gauss.mseed'
+    self.opdict['kurtglob']='*filt_kurt.mseed'
+    self.opdict['gradglob']='*filt_kurt_grad.mseed'
+    self.opdict['gaussglob']='*filt_kurt_grad_gauss.mseed'
 
     self.opdict['load_ttimes_buf']=True
 

--- a/PyProgs/options.py
+++ b/PyProgs/options.py
@@ -641,7 +641,7 @@ class WavelocOptions(object):
   
   def _verify_dd_loc(self):
     if not self.opdict.has_key('dd_loc'):
-        raise UserWarning('dd_loc option not set') 
+        raise UserWarning('dd_loc option not set')
 
   def _verify_syn_addnoise(self):
     if not self.opdict.has_key('syn_addnoise'):

--- a/PyProgs/test/test_clustering.py
+++ b/PyProgs/test/test_clustering.py
@@ -1,0 +1,32 @@
+import os, glob, unittest
+from options import WavelocOptions
+from OP_waveforms import Waveform
+from clustering import *
+import numpy as np
+
+def suite():
+  suite = unittest.TestSuite()
+  suite.addTest(unittest.makeSuite(ClusteringTest))
+  return suite
+
+class ClusteringTest(unittest.TestCase):
+
+  def setUp(self):
+
+    self.event=5
+    self.threshold=0.8
+    self.coeff={'A':[[1,1,0.3,0.7,0.8],[0,1,0.5,0.2,1],[0,0,1,0.6,0.8],[0,0,0,1,0.4],[0,0,0,0,1]],'B':[[1,1,0.3,0.7,0.8],[0,1,0.5,0.2,1],[0,0,1,0.6,0.8],[0,0,0,1,0.4],[0,0,0,0,1]],'C':[[1,1,0.3,0.7,0.8],[0,1,0.5,0.2,1],[0,0,1,0.6,0.8],[0,0,0,1,0.4],[0,0,0,0,1]]}
+    self.nbsta=np.matrix([[3,3,0,0,3],[0,3,0,0,3],[0,0,3,0,3],[0,0,0,3,0],[0,0,0,0,3]])
+    self.nbmin=2
+    self.cluster={1:[1,2,3,5]}
+
+  def test_nbsta(self):
+    exp_nbsta=compute_nbsta(self.event,self.coeff,self.threshold)
+    self.assertEqual(exp_nbsta.all(),self.nbsta.all())
+
+  def test_clustering(self):
+    exp_cluster=do_clustering(self.event,self.nbsta,self.nbmin)
+    self.assertEqual(exp_cluster,self.cluster)
+
+if __name__ == '__main__':
+  unittest.TextTestRunner(verbosity=2).run(suite())

--- a/PyProgs/test/test_waveloc.py
+++ b/PyProgs/test/test_waveloc.py
@@ -57,7 +57,7 @@ class SetupTests(unittest.TestCase):
 if __name__ == '__main__':
 
   import test_processing, test_migration, test_location, test_hdf5, test_nllstuff, test_correlation
-  import test_double_diff
+  import test_double_diff, test_clustering
   import logging
   logging.basicConfig(level=logging.INFO, format='%(levelname)s : %(asctime)s : %(message)s')
  
@@ -69,6 +69,7 @@ if __name__ == '__main__':
     test_hdf5.suite(),
     test_nllstuff.suite(),
     test_correlation.suite(),
+    test_clustering.suite(),
     test_double_diff.suite(),
     ]
 


### PR DESCRIPTION
- Main changes are in double_diff.py: similar events which are too far from the centroid are relocated to the centroid. It works much better for most crises. I still have some trouble for the crisis of the 29th october 2010 and I don't know why, but I'm going to have a look at it.
- I also made minor changes in SDS_processing.py: filenames are directly read from the option dictionary.
- in locations_trigger.py: the program keeps running even though data are missing.

@amaggi
