### PR TITLE
Synthetic resolution test example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 *.swo
 *.tgz
 *.prof
+*.png
 /nll/
 .DS_store
 /test_data/*.tgz

--- a/examples/run_syn_resolution_example.py
+++ b/examples/run_syn_resolution_example.py
@@ -121,7 +121,10 @@ def analyseLocs(locs,wo,test_info) :
 
     return n_locs,loc_dist,loc_dt,trig_loc
 
-def doResolutionTest(wo,grid_info,filename,loclevel=10.0,decimation=1) :
+def doResolutionTest(wo,grid_info,filename,loclevel=10.0,decimation=(1,1,1)) :
+
+    dec_x,dec_y,dec_z = decimation
+
 
     # get information from search grid
     nx = grid_info['nx']
@@ -129,9 +132,9 @@ def doResolutionTest(wo,grid_info,filename,loclevel=10.0,decimation=1) :
     nz = grid_info['nz']
 
     # get decimated grid
-    nx_dec = int(nx/decimation)
-    ny_dec = int(ny/decimation)
-    nz_dec = int(nz/decimation)
+    nx_dec = int(nx/dec_x)
+    ny_dec = int(ny/dec_y)
+    nz_dec = int(nz/dec_z)
     nb_dec = nx_dec*ny_dec*nz_dec
 
     # create info for decimated grid
@@ -139,9 +142,9 @@ def doResolutionTest(wo,grid_info,filename,loclevel=10.0,decimation=1) :
     dec_grid_info['nx'] = nx_dec
     dec_grid_info['ny'] = ny_dec
     dec_grid_info['nz'] = nz_dec
-    dec_grid_info['dx'] = grid_info['dx']*decimation
-    dec_grid_info['dy'] = grid_info['dy']*decimation
-    dec_grid_info['dz'] = grid_info['dz']*decimation
+    dec_grid_info['dx'] = grid_info['dx']*dec_x
+    dec_grid_info['dy'] = grid_info['dy']*dec_y
+    dec_grid_info['dz'] = grid_info['dz']*dec_z
     dec_grid_info['x_orig'] = grid_info['x_orig']
     dec_grid_info['y_orig'] = grid_info['y_orig']
     dec_grid_info['z_orig'] = grid_info['z_orig']
@@ -159,9 +162,9 @@ def doResolutionTest(wo,grid_info,filename,loclevel=10.0,decimation=1) :
         ix_dec,iy_dec,iz_dec = np.unravel_index(ib_dec,(nx_dec,ny_dec,nz_dec))
 
         # reconstruct the indexes in the original grid 
-	ix = ix_dec*decimation
-	iy = iy_dec*decimation
-	iz = iz_dec*decimation
+	ix = ix_dec*dec_x
+	iy = iy_dec*dec_y
+	iz = iz_dec*dec_z
 
         wo.opdict['syn_ix'] = ix
         wo.opdict['syn_iy'] = iy
@@ -282,7 +285,7 @@ if __name__ == '__main__' :
     plot_filename = 'waveloc_resolution.png'
 
     wo,grid_info = setUp()
-    #doResolutionTest(wo,grid_info,hdf_filename,loclevel=10.0,decimation=5)
+    doResolutionTest(wo,grid_info,hdf_filename,loclevel=10.0,decimation=(5,5,3))
     plotResolutionTest(hdf_filename,plot_filename)
 
 

--- a/examples/run_syn_resolution_example.py
+++ b/examples/run_syn_resolution_example.py
@@ -1,0 +1,141 @@
+import os, logging, h5py
+import numpy as np
+from random import randint
+from waveloc.NllGridLib import read_hdr_file
+from waveloc.options import WavelocOptions
+from waveloc.synth_migration import generateSyntheticDirac
+from waveloc.locations_trigger import trigger_locations_inner
+
+logging.basicConfig(level=logging.INFO, format='%(levelname)s : %(asctime)s : %(message)s')
+
+def setUp() :
+
+    logging.info('Setting up synthetic test case generation...')
+
+    # set up default parameters
+    wo = WavelocOptions()
+
+    # set base path to $WAVELOC_PATH
+    wo.verify_base_path()
+
+    # set options for synthetic test
+    wo.opdict['time']    = True
+    wo.opdict['verbose'] = False
+
+    wo.opdict['outdir'] = 'TEST_Dirac'
+    wo.opdict['time_grid'] = 'Slow_len.100m.P'
+    wo.opdict['load_ttimes_buf'] = True
+    wo.opdict['search_grid'] = 'grid.Taisne.search.hdr'
+    wo.opdict['stations'] = 'coord_stations_test'
+
+    wo.opdict['syn_filename']   = 'test_grid4D_hires.hdf5'
+    wo.opdict['syn_amplitude']  = 1.0
+    wo.opdict['syn_datalength'] = 20.0
+    wo.opdict['syn_samplefreq'] = 100.0
+    wo.opdict['syn_kwidth']     = 0.1
+    wo.opdict['syn_otime']      = 6.0
+
+    # place default point at center of grid
+    base_path = wo.opdict['base_path']
+    search_grid_filename = os.path.join(base_path,'lib',wo.opdict['search_grid'])
+    grid_info = read_hdr_file(search_grid_filename)
+    wo.opdict['syn_ix'] = grid_info['nx']/2
+    wo.opdict['syn_iy'] = grid_info['ny']/2
+    wo.opdict['syn_iz'] = grid_info['nz']/2
+
+    # sanity check
+    wo.verify_synthetic_options()
+
+    return (wo,grid_info)
+
+def doPointTest(wo,loclevel=10.0) :
+    
+    logging.info('Doing synthetic test for point (%d,%d,%d)...'\
+        %(wo.opdict['syn_ix'],wo.opdict['syn_iy'],wo.opdict['syn_iz']))
+
+    # do the migration
+    test_info = generateSyntheticDirac(wo.opdict)
+    logging.info(test_info)
+
+    # retrieve output info
+    stack_filename = test_info['stack_file']
+    nx,ny,nz,nt = test_info['grid_shape']
+    dx,dy,dz,dt = test_info['grid_spacing']
+    x_orig,y_orig,z_orig = test_info['grid_orig']
+    ix_true,iy_true,iz_true,it_true = test_info['true_indexes']
+    stack_start_time = test_info['start_time']
+
+    # set up x, y, z, t arrays
+    x = np.arange(nx)*dx
+    y = np.arange(ny)*dy
+    z = np.arange(nz)*dz
+    t = np.arange(nt)*dt+stack_start_time
+
+    # extract the max stacks
+    f_stack=h5py.File(stack_filename,'r')
+    max_val = f_stack['max_val']
+    max_x = f_stack['max_x']
+    max_y = f_stack['max_y']
+    max_z = f_stack['max_z']
+
+    # launch a location trivver
+    locs=trigger_locations_inner(max_val,max_x,max_y,max_z,\
+        loclevel,loclevel,stack_start_time,dt)
+    
+    f_stack.close()
+    return test_info,locs
+
+def analyseLocs(locs,wo,test_info) :
+
+    dx,dy,dz,dt = test_info['grid_spacing']
+    x_orig,y_orig,z_orig = test_info['grid_orig']
+    ix_true,iy_true,iz_true,it_true = test_info['true_indexes']
+
+    # This is a dirac test, but we may have more than one loc (secondary maxima)
+    # so for safety, pull out best loc
+
+
+    n_locs = len(locs)
+    if n_locs > 0 :
+        imax = np.argmax([loc['max_trig'] for loc in locs])
+        trig_loc = locs[imax]
+        print trig_loc['max_trig']
+
+        loc_dist = np.sqrt( (ix_true*dx+x_orig - trig_loc['x_mean'])**2 +\
+                            (iy_true*dy+y_orig - trig_loc['y_mean'])**2 +\
+                            (iz_true*dy+z_orig - trig_loc['z_mean'])**2)
+        loc_dt = trig_loc['o_time'] - wo.opdict['syn_otime']
+        loc_dt_list = [aloc['o_time'] - wo.opdict['syn_otime'] for aloc in locs]
+        print loc_dt_list
+    else :
+	loc_dist = None
+        loc_dt = None
+  
+
+    return n_locs,loc_dist,loc_dt
+
+
+if __name__ == '__main__' :
+
+
+    wo,grid_info = setUp()
+
+    # get information from search grid
+    nx = grid_info['nx']
+    ny = grid_info['ny']
+    nz = grid_info['nz']
+
+    # set up random test point
+    ix = randint(0,nx)
+    iy = randint(0,ny)
+    iz = randint(0,nz)
+    wo.opdict['syn_ix'] = ix
+    wo.opdict['syn_iy'] = iy
+    wo.opdict['syn_iz'] = iz
+
+    # do synthetic test for this point
+    test_info, locs = doPointTest(wo,loclevel=10.0)
+    n_locs,best_dist,best_dt = analyseLocs(locs,wo,test_info)
+
+    print ix,iy,iz,n_locs,best_dist,best_dt
+

--- a/examples/run_syn_resolution_example.py
+++ b/examples/run_syn_resolution_example.py
@@ -195,8 +195,6 @@ def doResolutionTest(wo,grid_info,filename,loclevel=10.0,decimation=(1,1,1)) :
     
 def plotResolutionTest(hdf_filename,plot_filename) :
 
-   
-
     # read HDF5 file
     f = h5py.File(hdf_filename,'r')
 
@@ -253,18 +251,28 @@ def plotResolutionTest(hdf_filename,plot_filename) :
     vmin_dt = np.min(dt_grid) 
     vmax_dt = np.max(dt_grid)
 
-    col=plt.cm.hot_r
-    plt.clf()
-    fig = plt.figure()
-    fig.suptitle('Resolution test depths %.2f to %.2f km'%(z_orig,(nz-1)*dz+z_orig))
-    # first z step
+
+    # filename
+    (root,ext) = os.path.splitext(plot_filename)
+
+    #col=plt.cm.hot_r
+    col=plt.cm.jet
+    # iterate over iz
     for iz in xrange(nz) : 
+        plt.clf()
+        fig = plt.figure(figsize=(10,4.5))
+   
+        # get depth
+        zvalue = iz*dz+z_orig
+        fname = root+'_%.2fkm'%zvalue+ext
+        #fig.suptitle('Resolution test depth %.2f km'%(zvalue))
+
         xy_cut_dist = dist_grid[:,:,iz]
         xy_cut_nloc = nloc_grid[:,:,iz]
         xy_cut_dt = dt_grid[:,:,iz]
         xy_extent = [np.min(x),np.max(x),np.min(y),np.max(y)]
 
-        p=plt.subplot(nz,3,iz*3+1)
+        p=plt.subplot(1,3,1)
         plt.imshow(xy_cut_dist.T,vmin=vmin_dist,vmax=vmax_dist,\
             origin='lower',interpolation='none',extent=xy_extent,cmap=col)
         p.tick_params(labelsize=10)
@@ -273,9 +281,9 @@ def plotResolutionTest(hdf_filename,plot_filename) :
         plt.ylabel('y (km wrt ref)',size=10)
         plt.colorbar(orientation='horizontal',ticks=[0,0.1,0.2,0.3,0.4])
 	plt.scatter(sta_x,sta_y)
-        plt.title('Distance')
+        plt.title('Distance (km)')
 
-        p=plt.subplot(nz,3,iz*3+2)
+        p=plt.subplot(1,3,2)
         plt.imshow(xy_cut_nloc.T,vmin=vmin_nloc,vmax=vmax_nloc,\
 	    origin='lower',interpolation='none',extent=xy_extent,cmap=col)
         p.tick_params(labelsize=10)
@@ -283,9 +291,9 @@ def plotResolutionTest(hdf_filename,plot_filename) :
         plt.xlabel('x (km wrt ref)',size=10)
         plt.colorbar(orientation='horizontal',ticks=[0,1,2,3])
 	plt.scatter(sta_x,sta_y)
-        plt.title('Nloc')
+        plt.title('No of locs')
 
-        p=plt.subplot(nz,3,iz*3+3)
+        p=plt.subplot(1,3,3)
         plt.imshow(xy_cut_dt.T,vmin=vmin_dt,vmax=vmax_dt,\
 	    origin='lower',interpolation='none',extent=xy_extent,cmap=col)
         p.tick_params(labelsize=10)
@@ -293,9 +301,9 @@ def plotResolutionTest(hdf_filename,plot_filename) :
         plt.xlabel('x (km wrt ref)',size=10)
         plt.colorbar(orientation='horizontal',ticks=[0,0.01,0.02,0.03])
 	plt.scatter(sta_x,sta_y)
-        plt.title('Delta origin time')
+        plt.title('Dt origin time (s)')
 
-    plt.savefig(plot_filename)
+        plt.savefig(fname)
 
 if __name__ == '__main__' :
 


### PR DESCRIPTION
Adds an example in the example directory to run a resolution test.
By default resolution is evaluated at every point in the search grid. The user can decimate the resolution test to optimize for speed. Resolution criteria are : (1) distance in km between true location and waveloc location (if more than one location is found, then only the one with the highest max_value is kept) ; (2) number of locations found by waveloc ; (3) origin time difference (waveloc - true).
